### PR TITLE
When attempting to sign in with an invalid user or with an invalid pa…

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,13 +58,11 @@ class UsersController < ApplicationController
       cookies.permanent[:user] = user.id
       redirect_to '/', notice: 'Logged in!'
     else
-      flash.alert = 'Invalid email or password'
-      render 'sign_in'
+      not_found
     end
   end
 
   def not_found
-    flash.alert = 'User not found'
-    redirect_to 'sign_in'
+    redirect_to sign_in_user_path, alert: 'User not found'
   end
 end


### PR DESCRIPTION
When attempting to sign in with an invalid password or invalid email,  the sign_in page would not refresh and it would stay at /user/begin_session instead of redirecting to /user/sign_in. This issue has been fixed.
